### PR TITLE
Change the function that is used within the var_dump_log().

### DIFF
--- a/lib/debug.inc
+++ b/lib/debug.inc
@@ -57,7 +57,7 @@ function print_r_html($var, $comment_out = true)
  */
 function var_dump_log($var)
 {
-   error_log(var_export($var, true));
+   error_log(var_dump($var, true));
 }
 
 /**


### PR DESCRIPTION
var_dump_log() という関数名と一致していなかったのであわせてみました。
何か意図があれば、却下して下さい。